### PR TITLE
Export kln_pointer

### DIFF
--- a/FindKallsymsLookupName.c
+++ b/FindKallsymsLookupName.c
@@ -97,3 +97,5 @@ module_exit(m_exit);
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("zizzu");
+
+EXPORT_SYMBOL(kln_pointer);


### PR DESCRIPTION
Exports kln_pointer to make it easier to just install this into a system.
(I'm using this because I need VRAM swap, and for VRAM swap I need `amdgpu_bo_create_kernel`. Thanks for this!)